### PR TITLE
Configuration fixes to enable local development of Captain and Assistant responses

### DIFF
--- a/enterprise/app/helpers/captain/chat_helper.rb
+++ b/enterprise/app/helpers/captain/chat_helper.rb
@@ -7,7 +7,7 @@ module Captain::ChatHelper
         model: @model,
         messages: @messages,
         tools: @tool_registry&.registered_tools || [],
-        response_format: { type: 'json_object' },
+        # response_format: { type: 'json_object' },
         temperature: @assistant&.config&.[]('temperature').to_f || 1
       }
     )
@@ -23,12 +23,26 @@ module Captain::ChatHelper
   def handle_response(response)
     Rails.logger.debug { "#{self.class.name} Assistant: #{@assistant.id}, Received response #{response}" }
     message = response.dig('choices', 0, 'message')
+    return nil if message.nil?
+
     if message['tool_calls']
       process_tool_calls(message['tool_calls'])
     else
-      message = JSON.parse(message['content'].strip)
-      persist_message(message, 'assistant')
-      message
+      content = message['content']&.strip
+      #Rails.logger.debug { "#{self.class.name} Assistant: #{@assistant.id}, Raw content: #{content}" }  #Added
+      return nil if content.blank?
+
+      begin
+        # Split by newline and take the first JSON object
+        first_json = content.split("\n").first
+        parsed_message = JSON.parse(first_json)  #instead of (content)
+        persist_message(parsed_message, 'assistant')
+        parsed_message
+      rescue JSON::ParserError => e
+        Rails.logger.error "#{self.class.name} Assistant: #{@assistant.id}, Error parsing response: #{e.message}"
+        Rails.logger.error "#{self.class.name} Assistant: #{@assistant.id}, Content that failed to parse: #{content}" #Added
+        { 'response' => content }
+      end
     end
   end
 


### PR DESCRIPTION
## Description

This PR adds the necessary configuration and response-handling updates to make the Captain and Assistant features function locally in development without enterprise edition UI access. These changes ensure that local developers can generate AI responses via the Rails console, using the OpenAI API and the AssistantChatService, without hitting JSON parser errors.

### Changes include:
- Fixed `handle_response` to correctly parse multi-line or malformed JSON outputs from OpenAI
- Removed `response_format: { type: 'json_object' }` to avoid format conflicts with prompt expectations
- Added fallback handling when JSON parsing fails to prevent runtime exceptions
- Verified functionality via Pry with direct `generate_response` calls
- `.env` file now includes the required `OPENAI_API_KEY` for authenticated testing

---
## Type of change

- [x] Configuration fix (to enable local development)
- [x] Error-handling improvement
---
## How Has This Been Tested?

- Tested manually via `bundle exec rails console`:
  - Created a `Captain::Assistant` instance
  - Initialized the `AssistantChatService`
  - Injected system/user messages
  - Verified that `generate_response` returns clean JSON-formatted hashes
- Verified that tool calls are triggered (e.g., `search_documentation`) and fallbacks work when no docs are found

<img width="959" alt="Screenshot 2025-06-08 213653" src="https://github.com/user-attachments/assets/86ccf91a-5708-4b7f-91c6-7df598c1f69b" />

---

## Notes

- The `OPENAI_API_KEY` must be added to your `.env` file for the assistant to work locally.
- System prompts and message structure must follow the JSON format: `{"reasoning": "...", "response": "..."}` to avoid parsing errors.